### PR TITLE
Prevent cluttering error log when used with MODX 2.3

### DIFF
--- a/core/components/dbapi/elements/plugins/plugin.dbapi.php
+++ b/core/components/dbapi/elements/plugins/plugin.dbapi.php
@@ -8,3 +8,4 @@
  */
 $modx->addPackage('modx.dbapi', $modx->getOption('components_path', $scriptProperties, MODX_CORE_PATH . 'components/') . 'dbapi/model/');
 $modx->getService('db', 'DBAPI');
+return;


### PR DESCRIPTION
This PR addresses issue #3, keeping the error log clean in MODX 2.3
